### PR TITLE
#2 - Implementar modo espelho

### DIFF
--- a/internal/backup_system/backup_system.go
+++ b/internal/backup_system/backup_system.go
@@ -171,8 +171,8 @@ func (bs *BackupSystem) sync(path string) error {
 }
 
 func (bs *BackupSystem) removeDeletedFiles() {
-	if bs.BackupMode == MIRROR {
-		// Percorre a tabela hash inteira se o MIRROR mod estiver ativo.
+	if bs.BackupMode == MIRROR && bs.BackupHistory.Len > 0 {
+		// Percorre a tabela hash inteira se o MIRROR mod estiver ativo e tiver algo gravado no histórico.
 		for key, value := range bs.BackupHistory.Data {
 			_, err := os.Stat(value.Path)
 

--- a/internal/data_structures/backup_table.go
+++ b/internal/data_structures/backup_table.go
@@ -17,9 +17,9 @@ type HashTable[T any] interface {
 }
 
 type BackupTable[T any] struct {
-	Size uint         `json:"size" gob:"size"`
-	Len  uint         `json:"len" gob:"len"`
-	Data map[string]T `json:"data" gob:"data"`
+	Size uint        
+	Len  uint        
+	Data map[string]T
 }
 
 func CreateBackupTable[T any](m uint) BackupTable[T] {

--- a/internal/data_structures/hash_table.go
+++ b/internal/data_structures/hash_table.go
@@ -10,6 +10,8 @@ type HashTable[T any] interface {
 	Alpha() float32
 	Insert(key string, value T) string
 	Search(key string) (string, T, bool)
+	Remove(key string) 
+	RemoveByHash(hash string)
 	Resize()
 	Print()
 }
@@ -69,6 +71,18 @@ func (bt *BackupTable[T]) Insert(key string, value T) string {
 	bt.Data[hash] = value
 
 	return hash
+}
+
+func (bt *BackupTable[T]) Remove(key string) {
+	hash, _, exists := bt.Search(key)
+
+	if exists {
+		delete(bt.Data, hash)
+	}
+}
+
+func (bt *BackupTable[T]) RemoveByHash(hash string) {	
+	delete(bt.Data, hash)
 }
 
 func (bt *BackupTable[T]) Print() {

--- a/internal/data_structures/hash_table.go
+++ b/internal/data_structures/hash_table.go
@@ -78,11 +78,13 @@ func (bt *BackupTable[T]) Remove(key string) {
 
 	if exists {
 		delete(bt.Data, hash)
+		bt.Len--
 	}
 }
 
 func (bt *BackupTable[T]) RemoveByHash(hash string) {	
 	delete(bt.Data, hash)
+	bt.Len--
 }
 
 func (bt *BackupTable[T]) Print() {


### PR DESCRIPTION
### Descrição
Nessa Issue foram implementados os modos do backup:
- **ESPELHO:** Reflete o que se passa no diretório raiz, inclusive excluindo arquivos.
- **PERSISTÊNCIA:** Persiste todos os arquivos, independente se foram excluídos na raiz o não.

Para que o modo espelho fosse possível foi implementado uma função que percorre a Hash e verifica cada caminho de origem em busca de alguém que foi excluído.
A remoção de arquivos é sempre chamada após a sincronização.

### Testes
- [x] Ao sincronizar um backup vazio não a chamamento do delete.
- [x] Se o MIRROR estiver ligado, reflete toda alteração na origem.
- [x] Caso o modo não seja MIRROR os arquivos excluídos não são removidos do Backup.
- [x] A Hash está sendo atualizada corretamente, arquivos excluídos são removidos da hash e a contagem de elementos permanece certa.
- [x] O arquivo de configuração é lido e salvo corretamente.
- [x] Funciona em ambos os SOs: Linux e Windows.

### Sugestão de teste
Modifique o main vazio mas não faça commit dessas alterações.
```go
const src = "caminho absoluto para o diretório alvo do backup"
const dst = "seucaminho/alp-backup-system/backup/" // Pasta de Backup no servidor
const configPath = "seucaminho/alp-backup-system/config" // Localização do arquivo de configuração

func main() {

	bs := backup_system.InitBackupSystem(dst, configPath)
	bs.SetBackupSrc(src)
	bs.Print()
	err := bs.Sync()
	if err != nil {
		log.Fatal(err)
	}
	bs.Print()
	bs.SetMode(backup_system.MIRROR) // Mude para alterar entre os modos
}
```